### PR TITLE
Fix pypi CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,30 +32,34 @@ jobs:
         with:
           submodules: 'true'
 
-      - name: Upgrade pip and build
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install --upgrade build
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.22.0
 
-      - name: Build wheel
-        run: python3 -m build
-            
       - name: Upload binary wheel
         uses: actions/upload-artifact@v4
         with:
-          name: dist
-          path: ./dist/*.whl
+          name: cibw-wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
       
   deploy:
+    environment:
+      name: pypi
+      url: https://pypi.org/p/libbash
     needs:
       - check-version-numbers
       - package-python
+    permissions:
+      id-token: write
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags')
       
     steps:
       - name: Download distributions
         uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: cibw-*
+          merge-multiple: true
 
       - name: Deploy test distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,14 +82,5 @@ jobs:
       - name: Deploy test distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           verbose: true
-          repository_url: https://test.pypi.org/legacy/
-          skip_existing: true            
-              
-      - name: Deploy tagged release on PyPI
-        if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          verbose: true
+          skip_existing: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        submodules: true  # Optional, use if you have submodules
+        submodules: true
 
     - name: Build SDist
       run: pipx run build --sdist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,23 @@ jobs:
 
       - name: Check version numbers
         run: ./version.sh
-  
+
+  make_sdist:
+    name: Make SDist
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true  # Optional, use if you have submodules
+
+    - name: Build SDist
+      run: pipx run build --sdist
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: cibw-sdist
+        path: dist/*.tar.gz
+
   package-python:
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,8 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - macos-13
+          - macos-latest
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         os:
+          - ubuntu-20.04 # earliest pash supports currently
           - ubuntu-latest
+          - macos-13
+          - macos-latest
     runs-on: ${{ matrix.os }}
     if: github.event.pull_request.draft == false
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,9 @@ Issues = "https://github.com/binpash/libbash/issues"
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel.macos]
+# doesn't work for some reason
+# shouldn't be necessary since bash has no
+# dependencies besides libc (checked on linux with audit wheel)
+repair-wheel-command = ""


### PR DESCRIPTION
The old build workflow didn’t build the wheels on the generic manylinux containers, so pypi rejected the build.
This uses the new pypi trusted publisher authentication method, so, assuming Seth has transferred the repo workflow, @angelhof could you go into the project settings and specify this action as the publisher?

